### PR TITLE
Support arithmoi-0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,33 +14,10 @@ env:
  - CABALVER=2.2  GHCVER=8.4.4
  - CABALVER=1.24 GHCVER=8.2.2
  - CABALVER=1.24 GHCVER=8.0.2
- - CABALVER=1.22 GHCVER=7.10.3
- - CABALVER=1.18 GHCVER=7.8.4
- - HPVER=2014.2.0.0
 
 # Note: the distinction between `before_install` and `install` is not
 #       important.
 before_install:
- - case "$HPVER" in
-    "") ;;
-
-    "2014.2.0.0")
-      export CABALVER=1.18 ;
-      export GHCVER=7.8.3 ;
-      echo "constraints:async==2.0.1.5,attoparsec==0.10.4.0,case-insensitive==1.1.0.3,fgl==5.5.0.1,GLUT==2.5.1.1,GLURaw==1.4.0.1,haskell-src==1.0.1.6,hashable==1.2.2.0,html==1.0.1.2,HTTP==4000.2.10,HUnit==1.2.5.2,mtl==2.1.3.1,network==2.4.2.3,OpenGL==2.9.2.0,OpenGLRaw==1.5.0.0,parallel==3.2.0.4,parsec==3.1.5,primitive==0.5.2.1,QuickCheck==2.6,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.2,split==0.2.2,stm==2.4.2,syb==0.4.1,text==1.1.0.0,transformers==0.3.0.0,unordered-containers==0.2.4.0,vector==0.10.9.1,xhtml==3000.2.1,zlib==0.5.4.1" > cabal.config ;;
-
-    "2012.2.0.0")
-      export CABALVER=1.16 ;
-      export GHCVER=7.4.1 ;
-      echo "constraints:cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.5,html==1.0.1.2,HTTP==4000.2.3,HUnit==1.2.4.2,mtl==2.1.1,network==2.3.0.13,OpenGL==2.2.3.1,parallel==3.2.0.2,parsec==3.1.2,QuickCheck==2.4.2,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.1,stm==2.3,syb==0.3.6.1,text==0.11.2.0,transformers==0.3.0.0,xhtml==3000.2.1,zlib==0.5.3.3" > cabal.config ;;
-
-    *)
-      export GHCVER=unknown ;
-      echo "unknown/invalid Haskell Platform requested" ;
-      exit 1 ;;
-
-   esac
-
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER

--- a/cyclotomic.cabal
+++ b/cyclotomic.cabal
@@ -39,7 +39,7 @@ Library
   Exposed-modules:   Data.Complex.Cyclotomic, Data.Number.RealCyclotomic
   Build-depends:     base >= 4.2 && < 4.14,
                      containers >= 0.3,
-                     arithmoi >= 0.5
+                     arithmoi >= 0.9
   default-language:  Haskell2010
   Hs-source-dirs:    src
 

--- a/src/Data/Complex/Cyclotomic.hs
+++ b/src/Data/Complex/Cyclotomic.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wall #-}
 {-# LANGUAGE Trustworthy #-}
 
-{- | 
+{- |
 Module      :  Data.Complex.Cyclotomic
 Copyright   :  (c) Scott N. Walck 2012-2017
 License     :  GPL-3 (see LICENSE)
@@ -10,23 +10,23 @@ Stability   :  experimental
 
 The cyclotomic numbers are a subset of the complex numbers with
 the following properties:
-    
+
      1.  The cyclotomic numbers are represented exactly, enabling exact
      computations and equality comparisons.
-    
+
      2.  The cyclotomic numbers contain the Gaussian rationals
      (complex numbers of the form 'p' + 'q' 'i' with 'p' and 'q' rational).
      As a consequence, the cyclotomic numbers are a dense subset of the
      complex numbers.
-    
+
      3.  The cyclotomic numbers contain the square roots of all rational numbers.
-    
+
      4.  The cyclotomic numbers form a field:  they are closed under addition, subtraction,
      multiplication, and division.
-    
+
      5.  The cyclotomic numbers contain the sine and cosine of all rational
      multiples of pi.
-    
+
      6.  The cyclotomic numbers can be thought of as the rational field extended
      with 'n'th roots of unity for arbitrarily large integers 'n'.
 
@@ -121,8 +121,15 @@ import qualified Data.Map as M
     , findWithDefault
     , fromListWith
     )
-import Math.NumberTheory.Primes.Factorisation
-    ( factorise
+import Math.NumberTheory.ArithmeticFunctions
+    ( runFunction
+    , totientA
+    , smallOmegaA
+    , isNFreeA
+    )
+import Math.NumberTheory.Primes
+    ( unPrime
+    , factorise
     )
 
 -- | A cyclotomic number.
@@ -223,8 +230,8 @@ sqrtPositiveInteger :: Integer -> Cyclotomic
 sqrtPositiveInteger n
     | n < 1      = error "sqrtPositiveInteger needs a positive integer"
     | otherwise  = let factors = factorise n
-                       factor = product [p^(m `div` 2) | (p,m) <- factors]
-                       nn     = product [p^(m `mod` 2) | (p,m) <- factors]
+                       factor = product [unPrime p ^ (m `div` 2) | (p, m) <- factors]
+                       nn     = product [unPrime p ^ (m `mod` 2) | (p, m) <- factors]
                    in case nn `mod` 4 of
                         1 -> fromInteger factor * (2 * eb nn + 1)
                         2 -> fromInteger factor * sqrt2 * sqrtPositiveInteger (nn `div` 2)
@@ -344,14 +351,8 @@ tryRational c
       (phi,nrp,sqfree) = phiNrpSqfree (order c)
 
 -- | Compute phi(n), the number of prime factors, and test if n is square-free.
---   We do these all together for efficiency, so we only call factorise once.
-phiNrpSqfree :: Integer -> (Integer,Int,Bool)
-phiNrpSqfree n = (phi,nrp,sqfree)
-    where
-      factors = factorise n
-      phi = foldr (\p n' -> n' `div` p * (p-1)) n [p | (p,_) <- factors]
-      nrp = length factors
-      sqfree = all (<=1) [m | (_,m) <- factors]
+phiNrpSqfree :: Integer -> (Integer, Int, Bool)
+phiNrpSqfree = runFunction $ (,,) <$> totientA <*> smallOmegaA <*> isNFreeA 2
 
 equalCoefficients :: Cyclotomic -> Maybe Rational
 equalCoefficients (Cyclotomic _ mp)
@@ -369,7 +370,7 @@ tryReduce :: Cyclotomic -> Cyclotomic
 tryReduce c
     = foldr reduceByPrime c squareFreeOddFactors
       where
-        squareFreeOddFactors = [p | (p,m) <- factorise (order c), p > 2, m <= 1]
+        squareFreeOddFactors = [unPrime p | (p, m) <- factorise (order c), unPrime p > 2, m <= 1]
 
 reduceByPrime :: Integer -> Cyclotomic -> Cyclotomic
 reduceByPrime p c@(Cyclotomic n _)
@@ -401,12 +402,12 @@ removeExps n 2 q = concatMap (includeMods n q) $ map ((n `div` q) *) [q `div` 2.
 removeExps n p q = concatMap (includeMods n q) $ map ((n `div` q) *) [-m..m]
     where m = (q `div` p - 1) `div` 2
 
-pqPairs :: Integer -> [(Integer,Integer)]
-pqPairs n = map (\(p,k) -> (p,p^k)) (factorise n)
+pqPairs :: Integer -> [(Integer, Integer)]
+pqPairs n = map (\(p, k) -> (unPrime p, unPrime p ^ k)) (factorise n)
 
 extraneousPowers :: Integer -> [(Integer,Integer)]
 extraneousPowers n
-    | n < 1      = error "extraneousPowers needs a postive integer"
+    | n < 1      = error "extraneousPowers needs a positive integer"
     | otherwise  = nub $ concat [[(p,r) | r <- removeExps n p q] | (p,q) <- pqPairs n]
 
 -- | Sum of two cyclotomic numbers.


### PR DESCRIPTION
https://github.com/commercialhaskell/stackage/issues/5306

`arithmoi >= 0.9` implies GHC >= 8.0, so I removed older platforms from Travis build. If it is important to continue their support, I can probably craft some unholy CPP mess, but it seems quite unwieldy to me.